### PR TITLE
Improve concatenation analyzer

### DIFF
--- a/HotPathAllocationAnalyzer.Test/Analyzers/ConcatenationAllocationAnalyzerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/ConcatenationAllocationAnalyzerTests.cs
@@ -8,20 +8,22 @@ namespace HotPathAllocationAnalyzer.Test.Analyzers
 {
     [TestClass]
     public class ConcatenationAllocationAnalyzerTests : AllocationAnalyzerTests {
+        
+        
         [TestMethod]
         public void ConcatenationAllocation_Basic() {
-            var snippet0 = @"string s0 = ""hello"" + 0.ToString() + ""world"" + 1.ToString();";
-            var snippet1 = @"string s2 = ""ohell"" + 2.ToString() + ""world"" + 3.ToString() + 4.ToString();";
+            var snippet0 = @"var s0 = ""hello"" + 0.ToString() + ""world"" + 1.ToString();";
+            var snippet1 = @"var s2 = ""ohell"" + 2.ToString() + ""world"" + 3.ToString() + 4.ToString();";
 
             var analyser = new ConcatenationAllocationAnalyzer(true);
             var info0 = ProcessCode(analyser, snippet0, ImmutableArray.Create(SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
             var info1 = ProcessCode(analyser, snippet1, ImmutableArray.Create(SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
 
-            Assert.AreEqual(0, info0.Allocations.Count(d => d.Id == ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id));
-            Assert.AreEqual(1, info1.Allocations.Count(d => d.Id == ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id));
-            AssertEx.ContainsDiagnostic(info1.Allocations, id: ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id, line: 1, character: 13);
+            //should raise once for every binary expression
+            Assert.AreEqual(3, info0.Allocations.Count(d => d.Id == ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id));
+            Assert.AreEqual(4, info1.Allocations.Count(d => d.Id == ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id));
         }
-
+        
         [TestMethod]
         public void ConcatenationAllocation_DoNotWarnForOptimizedValueTypes() {
             var snippets = new[]

--- a/HotPathAllocationAnalyzer.Test/Analyzers/StackOverflowAnswerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/StackOverflowAnswerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Reflection.PortableExecutable;
 using HotPathAllocationAnalyzer.Analyzers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -79,12 +80,14 @@ namespace HotPathAllocationAnalyzer.Test.Analyzers
         {
             var @script =
                 @"System.DateTime c = System.DateTime.Now;;
-                string s1 = ""char value will box"" + c;";
+                string s1 = ""dateTime value will box"" + c;";
             var analyser = new ConcatenationAllocationAnalyzer(true);
             var info = ProcessCode(analyser, @script, ImmutableArray.Create(SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression));
-            Assert.AreEqual(1, info.Allocations.Count);
+            //one allocation for boxing and one allocation for concatenation.
+            Assert.AreEqual(2, info.Allocations.Count);
             //Diagnostic: (2,53): warning HeapAnalyzerBoxingRule: Value type (char) is being boxed to a reference type for a string concatenation.
-            AssertEx.ContainsDiagnostic(info.Allocations, ConcatenationAllocationAnalyzer.ValueTypeToReferenceTypeInAStringConcatenationRule.Id, line: 2, character: 53);
+            AssertEx.ContainsDiagnostic(info.Allocations, ConcatenationAllocationAnalyzer.ValueTypeToReferenceTypeInAStringConcatenationRule.Id, line: 2, character: 57);
+            AssertEx.ContainsDiagnostic(info.Allocations, ConcatenationAllocationAnalyzer.StringConcatenationAllocationRule.Id, line: 2, character: 29);
         }
 
         [TestMethod]

--- a/HotPathAllocationAnalyzer/Analyzers/ConcatenationAllocationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/ConcatenationAllocationAnalyzer.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Collections.Immutable;
-using System.Linq;
+using ClrHeapAllocationAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace HotPathAllocationAnalyzer.Analyzers 
+namespace HotPathAllocationAnalyzer.Analyzers
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class ConcatenationAllocationAnalyzer : AllocationAnalyzer
     {
-        public static DiagnosticDescriptor StringConcatenationAllocationRule = new DiagnosticDescriptor("HAA0201", "Implicit string concatenation allocation", "Considering using StringBuilder", "Performance", DiagnosticSeverity.Error, true, string.Empty, "https://docs.microsoft.com/en-us/dotnet/standard/base-types/stringbuilder");
+        public static DiagnosticDescriptor StringConcatenationAllocationRule = new DiagnosticDescriptor("HAA0201", "Implicit string concatenation allocation", "Implicit string concatenation allocation", "Performance", DiagnosticSeverity.Error, true, string.Empty, "https://docs.microsoft.com/en-us/dotnet/standard/base-types/stringbuilder");
 
         public static DiagnosticDescriptor ValueTypeToReferenceTypeInAStringConcatenationRule = new DiagnosticDescriptor("HAA0202", "Value type to reference type conversion allocation for string concatenation", "Value type ({0}) is being boxed to a reference type for a string concatenation.", "Performance", DiagnosticSeverity.Error, true, string.Empty, "https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/boxing-and-unboxing");
-        
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(StringConcatenationAllocationRule, ValueTypeToReferenceTypeInAStringConcatenationRule);
 
-        protected override SyntaxKind[] Expressions => new[] { SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression };
+        protected override SyntaxKind[] Expressions => new[] {SyntaxKind.AddExpression, SyntaxKind.AddAssignmentExpression};
 
         private static readonly object[] EmptyMessageArgs = { };
 
@@ -25,7 +25,8 @@ namespace HotPathAllocationAnalyzer.Analyzers
         {
         }
 
-        public ConcatenationAllocationAnalyzer(bool forceAnalysis) : base(forceAnalysis)
+        public ConcatenationAllocationAnalyzer(bool forceAnalysis)
+            : base(forceAnalysis)
         {
         }
         
@@ -36,18 +37,15 @@ namespace HotPathAllocationAnalyzer.Analyzers
             Action<Diagnostic> reportDiagnostic = context.ReportDiagnostic;
             var cancellationToken = context.CancellationToken;
             string filePath = node.SyntaxTree.FilePath;
-            var binaryExpressions = node.DescendantNodesAndSelf().OfType<BinaryExpressionSyntax>().Reverse(); // need inner most expressions
 
-            int stringConcatenationCount = 0;
-            foreach (var binaryExpression in binaryExpressions) {
-                if (binaryExpression.Left == null || binaryExpression.Right == null) {
-                    continue;
-                }
+            if (node is BinaryExpressionSyntax binaryExpression)
+            {
+                if (binaryExpression.Left == null || binaryExpression.Right == null)
+                    return;
 
                 bool isConstant = semanticModel.GetConstantValue(binaryExpression, cancellationToken).HasValue;
-                if (isConstant) {
-                    continue;
-                }
+                if (isConstant)
+                    return;
 
                 var left = semanticModel.GetTypeInfo(binaryExpression.Left, cancellationToken);
                 var leftConversion = semanticModel.GetConversion(binaryExpression.Left, cancellationToken);
@@ -57,29 +55,24 @@ namespace HotPathAllocationAnalyzer.Analyzers
                 var rightConversion = semanticModel.GetConversion(binaryExpression.Right, cancellationToken);
                 CheckTypeConversion(right, rightConversion, reportDiagnostic, binaryExpression.Right.GetLocation(), filePath);
 
-                // regular string allocation
-                if (left.Type?.SpecialType == SpecialType.System_String || right.Type?.SpecialType == SpecialType.System_String) {
-                      stringConcatenationCount++;   
+                if (left.Type?.SpecialType == SpecialType.System_String || right.Type?.SpecialType == SpecialType.System_String)
+                {
+                    reportDiagnostic(Diagnostic.Create(StringConcatenationAllocationRule, node.GetLocation(), EmptyMessageArgs));
+                    HeapAllocationAnalyzerEventSource.Logger.StringConcatenationAllocation(filePath);
                 }
-            }
-
-            if (stringConcatenationCount > 3)
-            {
-                reportDiagnostic(Diagnostic.Create(StringConcatenationAllocationRule, node.GetLocation(), EmptyMessageArgs));
-                HeapAllocationAnalyzerEventSource.Logger.StringConcatenationAllocation(filePath);
             }
         }
 
-        private static void CheckTypeConversion(TypeInfo typeInfo, Conversion conversionInfo, Action<Diagnostic> reportDiagnostic, Location location, string filePath) {
-            bool IsOptimizedValueType(ITypeSymbol type) {
-                return type.SpecialType == SpecialType.System_Boolean ||
-                       type.SpecialType == SpecialType.System_Char ||
-                       type.SpecialType == SpecialType.System_IntPtr ||
-                       type.SpecialType == SpecialType.System_UIntPtr;
+        private static void CheckTypeConversion(TypeInfo typeInfo, Conversion conversionInfo, Action<Diagnostic> reportDiagnostic, Location location, string filePath)
+        {
+            bool IsOptimizedValueType(ITypeSymbol type)
+            {
+                return type.SpecialType == SpecialType.System_Boolean || type.SpecialType == SpecialType.System_Char || type.SpecialType == SpecialType.System_IntPtr || type.SpecialType == SpecialType.System_UIntPtr;
             }
 
-            if (conversionInfo.IsBoxing && !IsOptimizedValueType(typeInfo.Type ?? throw new Exception("Type is null in check conversion"))) {
-                reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeInAStringConcatenationRule, location, new[] { typeInfo.Type.ToDisplayString() }));
+            if (conversionInfo.IsBoxing && !IsOptimizedValueType(typeInfo.Type ?? throw new Exception("Type is null in check conversion")))
+            {
+                reportDiagnostic(Diagnostic.Create(ValueTypeToReferenceTypeInAStringConcatenationRule, location, new[] {typeInfo.Type.ToDisplayString()}));
                 HeapAllocationAnalyzerEventSource.Logger.BoxingAllocationInStringConcatenation(filePath);
             }
         }


### PR DESCRIPTION
Fix previous concatenation analyzer implementation :
* Don't trigger for concatenation used in property/field creation
* Trigger when an allocation is found (previously it would return an error only when the concatenation make more than 3 allocations (and ask to use a string builder instead))