### PR TITLE
Ignore property constructor

### DIFF
--- a/HotPathAllocationAnalyzer/Analyzers/AllocationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/AllocationAnalyzer.cs
@@ -33,7 +33,7 @@ namespace HotPathAllocationAnalyzer.Analyzers
         private void Analyze(SyntaxNodeAnalysisContext context)
         {
             var analyze = _forceEnableAnalysis
-                          || (AttributeHelper.HasNoAllocationAttribute(context.ContainingSymbol)
+                          || (AttributeHelper.ShouldAnalyzeNode(context.ContainingSymbol)
                               && !AttributeHelper.HasIgnoreAllocationAttribute(context.ContainingSymbol));
             if (analyze)
                 AnalyzeNode(context);

--- a/HotPathAllocationAnalyzer/Analyzers/ExplicitAllocationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/ExplicitAllocationAnalyzer.cs
@@ -127,17 +127,6 @@ namespace HotPathAllocationAnalyzer.Analyzers
             if (!IsReferenceType(context, node))
                 return;
 
-            var exceptions = new List<List<SyntaxKind>>
-            {
-                new() {SyntaxKind.EqualsValueClause, SyntaxKind.PropertyDeclaration}
-            };
-
-            foreach (var path in exceptions)
-            {
-                if (node.SearchPath(path.ToArray()) != null)
-                    return;
-            }
-            
             //These paths are multiple scenarios to have nicer error messages
             //If we don't match any we juste display the location of the node
             var paths = new List<List<SyntaxKind>>

--- a/HotPathAllocationAnalyzer/Helpers/AttributeHelper.cs
+++ b/HotPathAllocationAnalyzer/Helpers/AttributeHelper.cs
@@ -7,6 +7,20 @@ namespace HotPathAllocationAnalyzer.Helpers
 {
     internal static class AttributeHelper
     {
+        public static bool ShouldAnalyzeNode(ISymbol containingSymbol)
+        {
+            if (containingSymbol.Kind == SymbolKind.Property)
+                return false;
+            if (containingSymbol is not IMethodSymbol methodSymbol)
+                return HasNoAllocationAttribute(containingSymbol);
+            if (methodSymbol.MethodKind is MethodKind.PropertyGet or MethodKind.PropertySet)
+            {
+                return HasNoAllocationAttribute(methodSymbol) || (methodSymbol.AssociatedSymbol != null && HasNoAllocationAttribute(methodSymbol.AssociatedSymbol));
+            }
+
+            return HasNoAllocationAttribute(containingSymbol);
+        }
+        
         public static bool HasNoAllocationAttribute(ISymbol containingSymbol)
         {
             return FindAttribute(containingSymbol, AllocationRules.IsNoAllocationAttribute);


### PR DESCRIPTION
& Remove obsolete property check in ExplicitAllocationAnalyzer

For exemple, this should not trigger an allocation error

[NoAllocation]
 public List<int> A {get; set;} = new List<int>();