### PR TITLE
Support string interpolation handler

### DIFF
--- a/HotPathAllocationAnalyzer.Configuration/ConfigurationReader.cs
+++ b/HotPathAllocationAnalyzer.Configuration/ConfigurationReader.cs
@@ -91,13 +91,20 @@ namespace HotPathAllocationAnalyzer.Configuration
                 if (arguments.Count != 1)
                     continue;
 
-                var lambdaExpr = arguments[0].Expression as ParenthesizedLambdaExpressionSyntax;
-                if (lambdaExpr == null)
-                    continue;
+                if (arguments[0].Expression is ParenthesizedLambdaExpressionSyntax lambdaExpr)
+                {
+                    var childSymbol = semanticModel.GetSymbolInfo(lambdaExpr.Body, token).Symbol;
+                    foreach (var p in SerializeSymbol(childSymbol))
+                        yield return p;   
+                }
 
-                var childSymbol = semanticModel.GetSymbolInfo(lambdaExpr.Body, token).Symbol;
-                foreach (var p in SerializeSymbol(childSymbol))
-                    yield return p;
+                if (arguments[0].Expression is TypeOfExpressionSyntax typeOfExpressionSyntax)
+                {
+                    var childSymbol = semanticModel.GetSymbolInfo(typeOfExpressionSyntax.Type, token).Symbol;
+                    if (childSymbol != null)
+                        yield return childSymbol.ToString();
+                }
+                
             }
         }
 
@@ -115,6 +122,7 @@ namespace HotPathAllocationAnalyzer.Configuration
             }
         }
         
+
         private static IEnumerable<string> SerializeSymbol(ISymbol? childSymbol)
         {
             switch (childSymbol)

--- a/HotPathAllocationAnalyzer.Configuration/ConfigurationReader.cs
+++ b/HotPathAllocationAnalyzer.Configuration/ConfigurationReader.cs
@@ -83,7 +83,7 @@ namespace HotPathAllocationAnalyzer.Configuration
             foreach (var invocationExpr in invocationsExpr)
             {
                 var symbol = semanticModel.GetSymbolInfo(invocationExpr, token).Symbol;
-                if (symbol?.Name != nameof(AllocationConfiguration.MakeSafe))
+                if (symbol?.Name != nameof(AllocationConfiguration.MakeStringInterpolationSafe))
                     continue;
 
                 var arguments = invocationExpr.ArgumentList.Arguments;

--- a/HotPathAllocationAnalyzer.Configuration/HotPathAllocationAnalyzer.Configuration.csproj
+++ b/HotPathAllocationAnalyzer.Configuration/HotPathAllocationAnalyzer.Configuration.csproj
@@ -16,9 +16,9 @@
         <PackageReleaseNotes>Upgrade to net 6.</PackageReleaseNotes>
         <PackageTags>hotpath performance clr allocations boxing closure displayclass delegate enumerator newobj roslyn analyzer diagnostic</PackageTags>
         <NoPackageAnalysis>true</NoPackageAnalysis>
+        
     </PropertyGroup>
-
-
+    
     <ItemGroup>
         <PackageReference Include="Buildalyzer" Version="5.0.0" />
         <PackageReference Include="Buildalyzer.Workspaces" Version="5.0.0" />
@@ -29,14 +29,12 @@
     <ItemGroup>
         <None Update="build\**" Pack="true" PackagePath="" />
         <None Include="$(OutputPath)\publish\**" Pack="true" PackagePath="bin"/>
-        <!-- Used if the build is called by dotnet pack instead of a dotnet release-->
-        <None Include="$(OutputPath)\**" Pack="true" PackagePath="bin" Condition="!Exists('bin')"/> 
     </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\HotPathAllocationAnalyzer\HotPathAllocationAnalyzer.csproj" />
     </ItemGroup>
-
+    
     <Target Name="ReplaceVersion" BeforeTargets="CoreCompile">
         <XmlPoke XmlInputPath="build\HotPathAllocationAnalyzer.Configuration.targets" Value="$(PackageVersion)" Query="Project/PropertyGroup/HotPathAllocationAnalyzerConfigurationVersion" />
     </Target>

--- a/HotPathAllocationAnalyzer.Configuration/build/HotPathAllocationAnalyzer.Configuration.targets
+++ b/HotPathAllocationAnalyzer.Configuration/build/HotPathAllocationAnalyzer.Configuration.targets
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <HotPathAllocationAnalyzerConfigurationVersion>1.0.8</HotPathAllocationAnalyzerConfigurationVersion>
     <HotPathAllocationAnalyzerConfigurationOutputPath>$(MSBuildProjectDirectory)</HotPathAllocationAnalyzerConfigurationOutputPath>
-    <HotPathAllocationAnalyzerConfigurationBinary>$(NuGetPackageRoot)HotPathAllocationAnalyzer.configuration/$(HotPathAllocationAnalyzerConfigurationVersion)/bin/HotPathAllocationAnalyzer.Configuration.exe</HotPathAllocationAnalyzerConfigurationBinary>
+    <HotPathAllocationAnalyzerConfigurationBinary>$(NuGetPackageRoot)/HotPathAllocationAnalyzer.configuration/$(HotPathAllocationAnalyzerConfigurationVersion)/bin/HotPathAllocationAnalyzer.Configuration.exe</HotPathAllocationAnalyzerConfigurationBinary>
   </PropertyGroup>
   <Target Name="GenerateAnalyzerConfiguration" BeforeTargets="CoreCompile" Condition="'$(IsRunningHotPathAllocationAnalyzerConfiguration)' == '' and '$(DesignTimeBuild)' != 'true'" Inputs="@(Compile)" Outputs="$(HotPathAllocationAnalyzerConfigurationOutputPath)/whitelist.txt">
     <Exec Command="$(HotPathAllocationAnalyzerConfigurationBinary) $(HotPathAllocationAnalyzerConfigurationOutputPath)" />

--- a/HotPathAllocationAnalyzer.Test/Analyzers/AllocationAnalyzerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/AllocationAnalyzerTests.cs
@@ -65,7 +65,7 @@ namespace HotPathAllocationAnalyzer.Test.Analyzers
         protected Info ProcessCode(DiagnosticAnalyzer analyzer, string sampleProgram,
             ImmutableArray<SyntaxKind> expected, bool allowBuildErrors = false, TestAdditionalFile[] additionalFiles = null)
         {
-            var options = new CSharpParseOptions(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.CSharp9);
+            var options = new CSharpParseOptions(kind: SourceCodeKind.Script, languageVersion: LanguageVersion.CSharp10);
             var tree = CSharpSyntaxTree.ParseText(sampleProgram, options);
             var compilation = CSharpCompilation.Create("Test", new[] { tree }, references);
 

--- a/HotPathAllocationAnalyzer.Test/Analyzers/ExplicitAllocationAnalyzerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/ExplicitAllocationAnalyzerTests.cs
@@ -290,57 +290,7 @@ var structTest = new PropertyStructTests()
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.TargetTypeNewRule.Id, line: 45, character: 9);
             AssertEx.ContainsDiagnostic(info.Allocations, id: ExplicitAllocationAnalyzer.TargetTypeNewRule.Id, line: 46, character: 9);
         }
-
-        [TestMethod]
-        public void ExplicitAllocation_ShouldNotTriggerOnPropertyConstructor()
-        {
-            var sampleProgram = @"
-using System;
-using System.Collections.Generic;
-
-public class Foo
-{
-    public List<int> A {get; set;} = new(); //should not trigger
-    public List<int> B {get; set;} = new List<int>() {1, 3, 5}; //should not trigger
-    public List<int> C => new () {1, 4, 6}; // allocate
-
-    public List<int> D
-    {
-        get
-        {
-            return new() { 1, 2, 3 }; // allocate
-        }
-        set
-        {
-            value = new() { 1, 2 }; // allocate
-        }
-    }
-
-    public DateTime E => new(); //no allocation
-
-    public DateTime F
-    {
-        get
-        {
-            return new(); // no allocation
-        }
-        set
-        {
-            value = new(); //no allocation
-        }
-    }
-
-
-}
-
-var foo = new Foo();
-";
-            var analyser = new ExplicitAllocationAnalyzer(true);
-            var expected = analyser.GetType().GetProperty("Expressions", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(analyser) as SyntaxKind[];
-            var info = ProcessCode(analyser, sampleProgram, expected.ToImmutableArray());
-            Assert.AreEqual(4, info.Allocations.Count);
-        }
-
+        
         [TestMethod]
         public void ExplicitAllocation_MethodReturns()
         {
@@ -349,7 +299,7 @@ using System;
 using System.Collections.Generic;
 public class Foo
 {
-    public List<int> Data {get; set;} = new() {1,2}; //does not allocate;
+    public List<int> Data {get; set;}
 
     public List<int> A(){
         return new() {1,5,6}; //allocate

--- a/HotPathAllocationAnalyzer.Test/Analyzers/StringInterpolationAnalyzerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/StringInterpolationAnalyzerTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Immutable;
+using HotPathAllocationAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HotPathAllocationAnalyzer.Test.Analyzers
+{
+    [TestClass]
+    public class StringInterpolationAnalyzerTests : AllocationAnalyzerTests
+    {
+        [TestMethod]
+        public void StringInterpolation_ShouldIgnoreWhitelistedHandler()
+        {
+            //language=cs
+            const string sample = @"
+            using System;
+            using System.Collections.Generic;
+
+            public void Testing() {
+                var buffer = new char[100];
+                var v = buffer.AsSpan().TryWrite($""ABC{123}X"", out var _); //does not allocate
+                Log($""Hello {123}""); //allocate
+                var name = ""Foo"";
+                var msg = $""Hello {name}""; //allocate
+            }
+
+            private static void Log(string error)
+            {
+                
+            }
+";
+            var analyser = new StringInterpolationAnalyzer(true);
+            analyser.AddToWhiteList("System.MemoryExtensions.TryWriteInterpolatedStringHandler");
+            var info = ProcessCode(analyser, sample, ImmutableArray.Create(SyntaxKind.InterpolatedStringExpression));
+
+            Assert.AreEqual(2, info.Allocations.Count);
+        }
+        
+        [TestMethod]
+        public void StringInterpolation_ShouldAllocateForUnknownHandler()
+        {
+            //language=cs
+            const string sample = @"
+            using System;
+            using System.Collections.Generic;
+
+            public void Testing() {
+                var buffer = new char[100];
+                var v = buffer.AsSpan().TryWrite($""ABC{123}X"", out var _); //does not allocate
+                Log($""Hello {123}""); //allocate
+                var name = ""Foo"";
+                var msg = $""Hello {name}""; //allocate
+            }
+
+            private static void Log(string error)
+            {
+                
+            }
+";
+            var analyser = new StringInterpolationAnalyzer(true);
+            var info = ProcessCode(analyser, sample, ImmutableArray.Create(SyntaxKind.InterpolatedStringExpression));
+
+            Assert.AreEqual(3, info.Allocations.Count);
+        }
+    }    
+}
+

--- a/HotPathAllocationAnalyzer.Test/Analyzers/TypeConversionAllocationAnalyzerTests.cs
+++ b/HotPathAllocationAnalyzer.Test/Analyzers/TypeConversionAllocationAnalyzerTests.cs
@@ -479,27 +479,6 @@ var f2 = (object)""5""; // NO Allocation
         }
 
         [TestMethod]
-        public void TypeConversionAllocation_InterpolatedStringWithInt_BoxingWarning() {
-            var sampleProgram = @"string s = $""{1}"";";
-
-            var analyser = new TypeConversionAllocationAnalyzer(true);
-            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.Interpolation));
-
-            Assert.AreEqual(1, info.Allocations.Count);
-            AssertEx.ContainsDiagnostic(info.Allocations, id: TypeConversionAllocationAnalyzer.ValueTypeToReferenceTypeConversionRule.Id, line: 1, character: 15);
-        }
-
-        [TestMethod]
-        public void TypeConversionAllocation_InterpolatedStringWithString_NoWarning() {
-            var sampleProgram = @"string s = $""{1.ToString()}"";";
-
-            var analyser = new TypeConversionAllocationAnalyzer(true);
-            var info = ProcessCode(analyser, sampleProgram, ImmutableArray.Create(SyntaxKind.Interpolation));
-
-            Assert.AreEqual(0, info.Allocations.Count);
-        }
-
-        [TestMethod]
         public void TypeConversionAllocation_DelegateAssignmentToReadonly_DoNotWarn()
         {
             string[] snippets =

--- a/HotPathAllocationAnalyzer/Analyzers/AllocationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/AllocationAnalyzer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using HotPathAllocationAnalyzer.Helpers;
+﻿using HotPathAllocationAnalyzer.Helpers;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -10,9 +7,6 @@ namespace HotPathAllocationAnalyzer.Analyzers
     public abstract class AllocationAnalyzer : DiagnosticAnalyzer
     {
         private readonly bool _forceEnableAnalysis;
-        protected bool _whitelistFound = false;
-
-
         protected abstract SyntaxKind[] Expressions { get; }
 
         protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context);
@@ -31,19 +25,6 @@ namespace HotPathAllocationAnalyzer.Analyzers
             context.EnableConcurrentExecution();
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.RegisterSyntaxNodeAction(Analyze, Expressions);
-        }
-
-        protected string[] GetWhiteListedSymbols(CompilationStartAnalysisContext context)
-        {
-            var additionalFiles = context.Options.AdditionalFiles;
-            var whitelistFile = additionalFiles.FirstOrDefault(x => string.Equals(Path.GetFileName(x.Path), "whitelist.txt", StringComparison.OrdinalIgnoreCase));
-            if (whitelistFile == null)
-                return Array.Empty<string>();
-            _whitelistFound = true;
-            return whitelistFile.GetText(context.CancellationToken)
-                                ?.Lines.Select(x => x.ToString())
-                                .ToArray()
-                   ?? Array.Empty<string>();
         }
 
         private void Analyze(SyntaxNodeAnalysisContext context)

--- a/HotPathAllocationAnalyzer/Analyzers/StringInterpolationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/StringInterpolationAnalyzer.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace HotPathAllocationAnalyzer.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class StringInterpolationAnalyzer : WhitelistedAnalyzer
+{
+    public StringInterpolationAnalyzer()
+    {
+    }
+
+    public StringInterpolationAnalyzer(bool forceAnalysis)
+        : base(forceAnalysis)
+    {
+    }
+
+    public static DiagnosticDescriptor InterpolatedStringRule = new("HAA801", "String interpolation allocation", "Please use a custom handler for the string interpolation to avoid allocations", "Performance", DiagnosticSeverity.Error, true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(InterpolatedStringRule);
+
+    private static readonly object[] EmptyMessageArgs = { };
+    
+    protected override SyntaxKind[] Expressions { get; } = new[]
+    {
+        SyntaxKind.InterpolatedStringExpression,
+    };
+
+    protected override void AnalyzeNode(SyntaxNodeAnalysisContext context)
+    {
+        var node = context.Node;
+        var semanticModel = context.SemanticModel;
+        var reportDiagnostic = context.ReportDiagnostic;
+
+        if (node is not InterpolatedStringExpressionSyntax interpolation)
+            return;
+        if (node.Parent is not ArgumentSyntax)
+        {
+            reportDiagnostic(Diagnostic.Create(InterpolatedStringRule, interpolation.GetLocation(), EmptyMessageArgs));
+            return;
+        }
+            
+        var typeInfo = semanticModel.GetTypeInfo(node);
+        var typeName = typeInfo.ConvertedType?.ToString();
+        if (typeName != null && _whitelistedSymbols.Contains(typeName))
+            return;
+        reportDiagnostic(Diagnostic.Create(InterpolatedStringRule, interpolation.GetLocation(), EmptyMessageArgs));
+    }
+}

--- a/HotPathAllocationAnalyzer/Analyzers/TypeConversionAllocationAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/TypeConversionAllocationAnalyzer.cs
@@ -34,7 +34,6 @@ namespace HotPathAllocationAnalyzer.Analyzers
             SyntaxKind.EqualsValueClause,
             SyntaxKind.Argument,
             SyntaxKind.ArrowExpressionClause,
-            SyntaxKind.Interpolation
         };
 
         private static readonly object[] EmptyMessageArgs = { };
@@ -98,12 +97,6 @@ namespace HotPathAllocationAnalyzer.Analyzers
             if (node is ConditionalExpressionSyntax conditionalExpressionSyntax)
             {
                 ConditionalExpressionCheck(conditionalExpressionSyntax, semanticModel, reportDiagnostic, filePath, cancellationToken);
-                return;
-            }
-
-            // string a = $"{1}";
-            if (node is InterpolationSyntax interpolationSyntax) {
-                InterpolationCheck(interpolationSyntax, semanticModel, reportDiagnostic, filePath, cancellationToken);
                 return;
             }
 

--- a/HotPathAllocationAnalyzer/Analyzers/WhitelistedAnalyzer.cs
+++ b/HotPathAllocationAnalyzer/Analyzers/WhitelistedAnalyzer.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace HotPathAllocationAnalyzer.Analyzers;
+
+public abstract class WhitelistedAnalyzer : AllocationAnalyzer
+{
+    public WhitelistedAnalyzer()
+    {
+        
+    }
+
+    public WhitelistedAnalyzer(bool forceEnableAnalysis)
+        : base(forceEnableAnalysis)
+    {
+        
+    }
+    
+    protected bool _whitelistFound = false;
+    protected readonly HashSet<string> _whitelistedSymbols = new();
+
+    public override void Initialize(AnalysisContext context)
+    {
+        base.Initialize(context);
+        context.RegisterCompilationStartAction(LoadWhitelistedSymbols);
+    }
+
+    private void LoadWhitelistedSymbols(CompilationStartAnalysisContext context)
+    {
+        var additionalFiles = context.Options.AdditionalFiles;
+        var whitelistFile = additionalFiles.FirstOrDefault(x => string.Equals(Path.GetFileName(x.Path), "whitelist.txt", StringComparison.OrdinalIgnoreCase));
+        if (whitelistFile == null)
+            return;
+        _whitelistFound = true;
+        _whitelistedSymbols.UnionWith(whitelistFile.GetText(context.CancellationToken)
+                                                   ?.Lines.Select(x => x.ToString())
+                                                   .ToArray()
+                                      ?? Array.Empty<string>());
+    }
+        
+    public void AddToWhiteList(string method)
+    {
+        _whitelistedSymbols.Add(method);
+    }
+        
+    protected void ReportError(SyntaxNodeAnalysisContext context, SyntaxNode node, string name, DiagnosticDescriptor diagnosticDescriptor, Action<string> logger)
+    {
+        var details = $"[{node} / {name}]";
+        if (!_whitelistFound)
+            details += " (no whitelist found)";
+        else if (_whitelistedSymbols.Count == 0)
+            details += $" (empty whitelist')";
+            
+        context.ReportDiagnostic(Diagnostic.Create(diagnosticDescriptor, node.GetLocation(), details));
+        logger.Invoke(node.SyntaxTree.FilePath);
+    }
+        
+}

--- a/HotPathAllocationAnalyzer/Support/AllocationConfiguration.cs
+++ b/HotPathAllocationAnalyzer/Support/AllocationConfiguration.cs
@@ -12,5 +12,10 @@ namespace HotPathAllocationAnalyzer.Support
         public void MakeSafe(Expression<Action> expression)
         {
         }
+
+        public void MakeSafe(Type type)
+        {
+            
+        }
     }
 }

--- a/HotPathAllocationAnalyzer/Support/AllocationConfiguration.cs
+++ b/HotPathAllocationAnalyzer/Support/AllocationConfiguration.cs
@@ -13,7 +13,7 @@ namespace HotPathAllocationAnalyzer.Support
         {
         }
 
-        public void MakeSafe(Type type)
+        public void MakeStringInterpolationSafe(Type type)
         {
             
         }

--- a/README.md
+++ b/README.md
@@ -67,4 +67,25 @@ public class TestConfiguration : AllocationConfiguration
         Console.WriteLine("Hello");
     }
 }
-```  
+```
+4. Compile this project to generate the whitelist.txt file
+5. In the analyzed projects add the whitelist.txt file as an additional file in the csproj or a targets file
+with the syntax : 
+
+``
+<AdditionalFiles Include="path_to_whitelist.txt" Visible="false" />
+``
+
+# Publishing
+
+For the analyzer the package is automatically generated after each build thus : 
+```bash
+dotnet build
+```
+
+Since the configuration is an exe, we need to include the bin folder in the nuget.
+But the copy of the files is made before the compilation thus it must be done in 2 steps : 
+```bash
+dotnet publish 
+dotnet pack --no-build --no-restore
+```


### PR DESCRIPTION
With the arrival of c# 10, user can implement custom string interpolation handler thus can be zero alloc.
By default all the interpolation handlers are supposed to allocate but we can whitelist the handler by putting the type in the whitelist file.